### PR TITLE
Supporting two enviroments (Beta and Prod) in build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
+# Gradle files
+gradle/
+gradlew
+gradlew.bat
+build/
+VideoLocker/gradle.properties
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Other project folders/files
+*.iml
+.idea/
+.DS_Store
+
+# Other files and directories to be ignored
 build
+.idea

--- a/src/main/groovy/org/edx/builder/Configuration.groovy
+++ b/src/main/groovy/org/edx/builder/Configuration.groovy
@@ -6,6 +6,7 @@ class Configuration {
     static final def IOS = 'IOS'
     static final def ANDROID = 'ANDROID'
     def platform
+    def env
 
     def androidConfig
     def iosConfig
@@ -22,11 +23,11 @@ class Configuration {
         if(androidConfig == null) {
             androidConfig = new AndroidConfiguration();
         }
-        action.delegate = androidConfig 
+        action.delegate = androidConfig
         action()
     }
 
-    def getActiveConfig() {
+    def getActiveConfig()   {
         if(platform.equals(IOS)) {
             return iosConfig
         }
@@ -39,6 +40,8 @@ class Configuration {
 
 class PlatformConfiguration {
     def configFiles = []
+    def betaConfigFiles = []
+    def devConfigFiles = []
 }
 
 class IOSConfiguration extends PlatformConfiguration {

--- a/src/main/groovy/org/edx/builder/TaskHelper.groovy
+++ b/src/main/groovy/org/edx/builder/TaskHelper.groovy
@@ -7,7 +7,7 @@ class TaskHelper {
     // List of files to load config keys from
     private def getConfigPaths(project) {
         def result = []
-        for(configName in project.edx.activeConfig.configFiles) {
+        for(configName in getConfigFiles(project)) {
             result.add(project.file(project.edx.dir + '/' + configName))
         }
         return result
@@ -53,7 +53,7 @@ class TaskHelper {
         println ""
         println "This command requires uncrustify (http://uncrustify.sourceforge.net)"
         println ""
-        
+
         files.visit { file ->
             if(!file.isDirectory()) {
                 project.exec {
@@ -61,6 +61,19 @@ class TaskHelper {
                     args '-c', '.uncrustify', '--replace', '--no-backup', '-l', 'OC', file.file.path
                 }
             }
+        }
+    }
+
+    def getConfigFiles(project)    {
+        switch (project.edx.env)    {
+            case 1:
+                return project.edx.activeConfig.configFiles
+            case 2:
+                return project.edx.activeConfig.betaConfigFiles
+            case 3:
+                return project.edx.activeConfig.devConfigFiles
+            default:
+                return project.edx.activeConfig.devConfigFiles
         }
     }
 }


### PR DESCRIPTION
This is allows us to separate our dev, beta, and production configurations. I had to ignore a lot of files so I've updated the _.gitignore_ file (I know it's better to do it in a separate commit, so I'll try to).

---

Related PRs:
- Configuration project: [#8](https://bitbucket.org/Edraak/mobile-apps-configs/pull-requests/8)
- Android project: [#42](https://bitbucket.org/Edraak/edraak-app-android/pull-requests/42)
- iOS project: N/A
